### PR TITLE
Update Spanish translation, including a missing string

### DIFF
--- a/localization/es_ES.inc
+++ b/localization/es_ES.inc
@@ -15,7 +15,7 @@ $labels['to'] = 'Para';
 $labels['cc'] = 'CC';
 $labels['subject'] = 'Asunto';
 $labels['delete'] = 'Eliminar';
-
+$labels['filterpriority'] = 'No aplicar otras reglas'
 $messages = array();
 $messages['nosearchstring'] = "El campo 'Contiene' no puede estar vacío.";
 $messages['successfullysaved'] = "Filtro almacenado éxitosamente.";


### PR DESCRIPTION
Thanks for working in the filters plugin for Roundcube.
I've updated the Spanish translation.