### PR TITLE
Render settings sidebar with RC's PHP API

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -11,11 +11,7 @@
 
 if (window.rcmail) {
   rcmail.addEventListener('init', function(evt) {
-    var tab = $('<span>').attr('id', 'settingstabpluginfilters').addClass('tablink');    
-    var button = $('<a>').attr('href', rcmail.env.comm_path+'&_action=plugin.filters').html(rcmail.gettext('filters', 'filters')).appendTo(tab);    
-        
-    // add button and register command
-    rcmail.add_element(tab, 'tabs');
+    // register command
     rcmail.register_command('plugin.filters-delete', function(){ rcmail.goto_url('plugin.filters-delete') }, true);    
     rcmail.register_command('plugin.filters-save', function(){ 
       var input_searchstring = rcube_find_object('_searchstring');      

--- a/filters.php
+++ b/filters.php
@@ -41,6 +41,7 @@ class filters extends rcube_plugin{
     if($this->rc->task == 'mail' && !isset($_GET["_q"]))
         $this->add_hook('messages_list', array($this, 'filters_checkmsg'));
     else if ($this->rc->task == 'settings'){
+        $this->add_hook('settings_actions', array($this, 'settings_actions'));
         $this->register_action('plugin.filters', array($this, 'filters_init'));
         $this->register_action('plugin.filters-save', array($this, 'filters_save'));
         $this->register_action('plugin.filters-delete', array($this, 'filters_delete'));
@@ -53,6 +54,17 @@ class filters extends rcube_plugin{
         $this->add_hook('login_after', array($this, 'filters_addMoveSpamRule'));
     }
 
+  }
+
+  function settings_actions($args){
+      $args['actions'][] = array(
+          'action' => 'plugin.filters',
+          'class' => 'filters',
+          'label' => 'filters',
+          'domain' => 'filters',
+      );
+
+      return $args;
   }
 
   function filters_checkmsg($mlist){


### PR DESCRIPTION
Roundcube has a PHP API to create a button to the sidebar list.
Create buttons via javascript codes like the following would be skin-dependent.

```js
    var tab = $('<span>').attr('id', 'settingstabpluginfilters').addClass('tablink');    
    var button = $('<a>').attr('href', rcmail.env.comm_path+'&_action=plugin.filters').html(rcmail.gettext('filters', 'filters')).appendTo(tab);    
```

Take the built-in Larry skin as an example. The javascript-created button is in a wrong place. It should be in the `ul` element and be wrapped with `li`. The PHP API does this automatically.

![image](https://user-images.githubusercontent.com/6594915/51761887-376fb200-2109-11e9-9aaa-325fae3059a7.png)

---

After patch:

![image](https://user-images.githubusercontent.com/6594915/51762340-69354880-210a-11e9-906b-bfa1c2b51a00.png)
