### PR TITLE
ADD: filter for mailing lists

### DIFF
--- a/filters.php
+++ b/filters.php
@@ -228,6 +228,7 @@ class filters extends rcube_plugin{
     $select->add($this->gettext('to'), 'to');
     $select->add($this->gettext('cc'), 'cc');
     $select->add($this->gettext('subject'), 'subject');
+    $select->add($this->gettext('list-post'), 'list-post');
     foreach ($this->spam_headers as $spam_header) $select->add($spam_header,$spam_header);
     $table->add('', $select->show($this->gettext('from')));
 
@@ -265,7 +266,7 @@ class filters extends rcube_plugin{
     $table->add('', $select->show($this->gettext('none')));
 
     // new option: filter priority, "on" as enable and "" as disable
-    $table->add('title', rcube_utils::rep_specialchars_output($this->gettext('filterpriority').":"), 'html');
+n    $table->add('title', rcube_utils::rep_specialchars_output($this->gettext('filterpriority').":"), 'html');
     $checkbox = new html_checkbox(array('name' => '_checkbox', 'id' => 'checkbox'));
     $table->add('', $checkbox->show("0"));
 
@@ -337,7 +338,7 @@ class filters extends rcube_plugin{
     // check if a message has been read
     if (isset($message->flags['SEEN']) && $message->flags['SEEN'])
       $msg_read = 1;
-      $headers = array_merge(array('from','to','cc','subject'), $this->spam_headers);
+      $headers = array_merge(array('from','to','cc','subject','list-post'), $this->spam_headers);
       $destination_folder = '';
       $filter_flag = '';
       $mark_flag = '';

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -9,6 +9,7 @@ $labels['moveto'] = 'Verschieben nach';
 $labels['from'] = 'Absender';
 $labels['to'] = 'Empfänger';
 $labels['cc'] = 'CC';
+$labels['list-post'] = 'Liste';
 $labels['subject'] = 'Betreff';
 $labels['delete'] = 'Löschen';
 

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -10,6 +10,7 @@ $labels['moveto'] = 'Move to';
 $labels['from'] = 'From';
 $labels['to'] = 'To';
 $labels['cc'] = 'CC';
+$labels['list-post'] = 'Mailing list';
 $labels['subject'] = 'Subject';
 $labels['delete'] = 'Delete';
 $labels['filterpriority'] = 'Do not apply other rules';


### PR DESCRIPTION
Mailing list send a mail header "list-post", which I use to filter such messages into specific folders. This patch adds the functionality to define "list-filters" and search a pattern within the "list-post" header.